### PR TITLE
Wrapping label in span to make them easier to target with CSS

### DIFF
--- a/UtilBundle/Resources/views/pagination/twitter_bootstrap_v3_pagination.html.twig
+++ b/UtilBundle/Resources/views/pagination/twitter_bootstrap_v3_pagination.html.twig
@@ -19,11 +19,12 @@
 
     {% if previous is defined %}
         <li class="page-item">
-            <a class="page-link" rel="prev" href="{{ path(route, query|merge({(pageParameterName): previous})) }}">&laquo;&nbsp;{{ 'label_previous'|trans([], 'KnpPaginatorBundle') }}</a>
+            <a class="page-link" rel="prev"
+               href="{{ path(route, query|merge({(pageParameterName): previous})) }}">&laquo;&nbsp;<span class="page-label">{{ 'label_previous'|trans([], 'KnpPaginatorBundle') }}</span></a>
         </li>
     {% else %}
         <li class="disabled page-item">
-            <a class="page-link">&laquo;&nbsp;{{ 'label_previous'|trans([], 'KnpPaginatorBundle') }}</a>
+            <a class="page-link">&laquo;&nbsp;<span class="page-label">{{ 'label_previous'|trans([], 'KnpPaginatorBundle') }}</span></a>
         </li>
     {% endif %}
 
@@ -74,11 +75,11 @@
 
     {% if next is defined %}
         <li class="page-item">
-            <a class="page-link" rel="next" href="{{ path(route, query|merge({(pageParameterName): next})) }}">{{ 'label_next'|trans([], 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+            <a class="page-link" rel="next" href="{{ path(route, query|merge({(pageParameterName): next})) }}"><span class="page-label">{{ 'label_next'|trans([], 'KnpPaginatorBundle') }}</span>&nbsp;&raquo;</a>
         </li>
     {% else %}
         <li class="disabled page-item">
-            <a class="page-link">{{ 'label_next'|trans([], 'KnpPaginatorBundle') }}&nbsp;&raquo;</a>
+            <a class="page-link"><span class="page-label">{{ 'label_next'|trans([], 'KnpPaginatorBundle') }}</span>&nbsp;&raquo;</a>
         </li>
     {% endif %}
     </ul>


### PR DESCRIPTION
Wrapping the previous and next strings in `<span>` elements to make it easier to manipulate using CSS.